### PR TITLE
Remover el underline de text-decoration por defecto

### DIFF
--- a/covid19.js
+++ b/covid19.js
@@ -38,7 +38,7 @@ document.addEventListener("DOMContentLoaded", function(event) {
     document.querySelector('body').innerHTML += codvid;
     insertCss(
     "#covid19 {position:fixed;bottom:10px;left:10px;width: 15%;background-color: #f5f5f5;z-index: 9999999999;border: 1px solid #ccc;}" +
-    "#covid19 img {max-width: 100%;max-height: 50px;margin: 10px;}" +
+    "#covid19 img {max-width: 100%;max-height: 50px;margin: 10px;}" + '#covid19{text-decoration: none;}' +
     ".covid19__hashtag {color: #555;font-size: 19px;font-weight: 800;text-align: center;}" +
     "@media (max-width: 767px) { #covid19 {width: 100%;bottom:0;left:0;} #covid19 img, .covid19__hashtag {width: 45%; float:left;} .covid19__hashtag {margin-top: 25px;}  }"
     );

--- a/covid19_de.js
+++ b/covid19_de.js
@@ -16,7 +16,7 @@ document.addEventListener("DOMContentLoaded", function(event) {
     document.querySelector('body').innerHTML += codvid;
     insertCss(
     "#covid19 {position:fixed;bottom:10px;left:10px;width: 15%;background-color: #f5f5f5;z-index: 999;border: 1px solid #ccc;}" +
-    "#covid19 img {max-width: 100%;max-height: 50px;margin: 10px;}" +
+    "#covid19 img {max-width: 100%;max-height: 50px;margin: 10px;}" + '#covid19{text-decoration: none;}' +
     ".covid19__hashtag {color: #555;font-size: 19px;font-weight: 800;text-align: center;}" +
     "@media (max-width: 767px) { #covid19 {width: 100%;bottom:0;left:0;} #covid19 img, .covid19__hashtag {width: 45%; float:left;} .covid19__hashtag {margin-top: 25px;}  }"
     );

--- a/covid19_en.js
+++ b/covid19_en.js
@@ -16,7 +16,7 @@ document.addEventListener("DOMContentLoaded", function(event) {
     document.querySelector('body').innerHTML += codvid;
     insertCss(
     "#covid19 {position:fixed;bottom:10px;left:10px;width: 15%;background-color: #f5f5f5;z-index: 999;border: 1px solid #ccc;}" +
-    "#covid19 img {max-width: 100%;max-height: 50px;margin: 10px;}" +
+    "#covid19 img {max-width: 100%;max-height: 50px;margin: 10px;}" + '#covid19{text-decoration: none;}' +
     ".covid19__hashtag {color: #555;font-size: 19px;font-weight: 800;text-align: center;}" +
     "@media (max-width: 767px) { #covid19 {width: 100%;bottom:0;left:0;} #covid19 img, .covid19__hashtag {width: 45%; float:left;} .covid19__hashtag {margin-top: 25px;}  }"
     );

--- a/covid19_es.js
+++ b/covid19_es.js
@@ -16,7 +16,7 @@ document.addEventListener("DOMContentLoaded", function(event) {
     document.querySelector('body').innerHTML += codvid;
     insertCss(
     "#covid19 {position:fixed;bottom:10px;left:10px;width: 15%;background-color: #f5f5f5;z-index: 999;border: 1px solid #ccc;}" +
-    "#covid19 img {max-width: 100%;max-height: 50px;margin: 10px;}" +
+    "#covid19 img {max-width: 100%;max-height: 50px;margin: 10px;}" + '#covid19{text-decoration: none;}' +
     ".covid19__hashtag {color: #555;font-size: 19px;font-weight: 800;text-align: center;}" +
     "@media (max-width: 767px) { #covid19 {width: 100%;bottom:0;left:0;} #covid19 img, .covid19__hashtag {width: 45%; float:left;} .covid19__hashtag {margin-top: 25px;}  }"
     );

--- a/covid19_fr.js
+++ b/covid19_fr.js
@@ -16,7 +16,7 @@ document.addEventListener("DOMContentLoaded", function(event) {
     document.querySelector('body').innerHTML += codvid;
     insertCss(
     "#covid19 {position:fixed;bottom:10px;left:10px;width: 15%;background-color: #f5f5f5;z-index: 999;border: 1px solid #ccc;}" +
-    "#covid19 img {max-width: 100%;max-height: 50px;margin: 10px;}" +
+    "#covid19 img {max-width: 100%;max-height: 50px;margin: 10px;}" + '#covid19{text-decoration: none;}' +
     ".covid19__hashtag {color: #555;font-size: 19px;font-weight: 800;text-align: center;}" +
     "@media (max-width: 767px) { #covid19 {width: 100%;bottom:0;left:0;} #covid19 img, .covid19__hashtag {width: 45%; float:left;} .covid19__hashtag {margin-top: 25px;}  }"
     );

--- a/covid19_it.js
+++ b/covid19_it.js
@@ -16,7 +16,7 @@ document.addEventListener("DOMContentLoaded", function(event) {
     document.querySelector('body').innerHTML += codvid;
     insertCss(
     "#covid19 {position:fixed;bottom:10px;left:10px;width: 15%;background-color: #f5f5f5;z-index: 999;border: 1px solid #ccc;}" +
-    "#covid19 img {max-width: 100%;max-height: 50px;margin: 10px;}" +
+    "#covid19 img {max-width: 100%;max-height: 50px;margin: 10px;}" + '#covid19{text-decoration: none;}' +
     ".covid19__hashtag {color: #555;font-size: 19px;font-weight: 800;text-align: center;}" +
     "@media (max-width: 767px) { #covid19 {width: 100%;bottom:0;left:0;} #covid19 img, .covid19__hashtag {width: 45%; float:left;} .covid19__hashtag {margin-top: 25px;}  }"
     );


### PR DESCRIPTION
Remueve el subrayado (underline) usando la propiedad `text-decoration` y el valor `none`.

Antes:
![before](https://user-images.githubusercontent.com/47821093/76719540-0fc21b80-6708-11ea-99ce-4c2fed7b64b3.PNG)

Después:
![after](https://user-images.githubusercontent.com/47821093/76719661-63cd0000-6708-11ea-8b68-2240dedf27aa.PNG)